### PR TITLE
Temporary fix for reading config files

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -1,8 +1,9 @@
 package config
 
-import (
-	"fmt"
+// TODO: config file path should probably be read from env variable or command line argument
 
+import (
+	log "github.com/Sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
@@ -19,18 +20,21 @@ func GetTokenValidityPeriod() int {
 
 func init() {
 	viper.SetConfigName("config")
-	viper.AddConfigPath(".")
+	viper.AddConfigPath("$GOPATH/src/github.com/VirrageS/chirp/backend")
 
 	err := viper.ReadInConfig()
 	if err != nil {
-		panic(fmt.Sprintf("Error reading config file: %v\n", err))
+		log.WithError(err).Fatal("Error reading config file.")
 	}
 
 	configSecretKey := viper.GetString("secret_key")
 	configValidityPeriod := viper.GetInt("token_validity_period")
+
 	if configSecretKey == "" || configValidityPeriod <= 0 {
-		panic(fmt.Sprintf("Config file contains invalid data! secretKey = %s, validityPeriod = %d",
-			configSecretKey, configValidityPeriod))
+		log.WithFields(log.Fields{
+			"secret key":      configSecretKey,
+			"validity period": configValidityPeriod,
+		}).Fatal("Config file doesn't contain valid data.")
 	}
 
 	secretKey = []byte(configSecretKey)


### PR DESCRIPTION
Add a temporary fix for reading config files. In future we will probably want to read path to config file from env variable or command line arguments.

closes #33