### PR TITLE
Add fake PostgreSQL table partition

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,4 +1,9 @@
-FROM postgres:latest
+FROM postgres:9.5
+
+RUN apt-get update
+RUN apt-get install -y git build-essential postgresql libpq-dev postgresql-server-dev-all postgresql-common
+RUN git clone https://github.com/keithf4/pg_partman.git
+RUN cd pg_partman && make NO_BGW=1 install
 
 COPY schema.sql /
 COPY fixtures.sql /

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -1,3 +1,7 @@
+CREATE SCHEMA partman;
+CREATE EXTENSION pg_partman SCHEMA partman;
+
+
 CREATE TABLE users (
   id               SERIAL PRIMARY KEY,
   twitter_token    VARCHAR(255) UNIQUE,
@@ -24,6 +28,13 @@ CREATE INDEX users_google_token_idx ON users (google_token);
 CREATE INDEX users_username_idx ON users (username);
 CREATE INDEX users_email_idx ON users (email);
 CREATE INDEX users_active_idx ON users (active);
+
+
+-- create partition on `id` field every 100000 rows
+-- SELECT partman.create_parent('public.users', 'id', 'id', '100000');
+
+-- create partition on `created_at` field every month 
+-- SELECT partman.create_parent('public.users', 'created_at', 'time', 'monthly');
 
 
 CREATE TABLE follows (


### PR DESCRIPTION
PostgreSQL table partition is shit. It looks like very few people use it and it has bad support. There is module/extension for PostgreSQL which I added called `pg_partman`. It helps to make partition automatically (or putting this more accurate: it should help). It looks like adding simple partition change structure of table/database and even simplest queries performed on partitioned table fail.

And look at this benchmarks. This look like shit: http://akorotkov.github.io/blog/2016/03/18/pg_pathman-update-delete-benchmark/.

I am done with table partitioning. It is not worth it. That is why I created this PR to make table partition fake. I think that it is better not doing it and just show how it could work and what are possible outcomes of this (mostly drawbacks I think when considering single node). 

@Prytu I know that you would like to do it anyway but unfortunately I made my mind and any PRs connected with table partition will be closed.

This is benchmark for MySQL: http://www.nilinfobin.com/mysql/performance-of-inserts-on-partitions-mysql-5-6-vs-mysql-5-7/. It also do not look promising. I think that one have to have a REEEALY big table to consider this. Moreover I think it is better create database cluster and partition data across the cluster instead of making table partition on single node. But since it is very time consuming and demanding we will not do that either.

That's it. I hope that I clarified everything.